### PR TITLE
update Caravel User Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ All Caravel user flow step outputs were written to log files.
     $ make user_proj_example
     $ make user_project_wrapper
     
+    $ cd ..
     Run gate level simulation (it will take 2~3 hours@i9/64GB)
     $ SIM=GL    
     $ make verify-la_test1-gl


### PR DESCRIPTION
I found a error in "make verify-la_test1-gl"
```
$ make verify-la_test1-gl
make: *** No rule to make target 'verify-la_test1-gl'.  Stop.
```
need cd .. to switch from caravel_user_project/openlane to caravel_user_project then "make verify-la_test1-gl".
